### PR TITLE
Fix easybuild environment creation

### DIFF
--- a/easybuild/global-install.sh
+++ b/easybuild/global-install.sh
@@ -27,6 +27,8 @@
 # ==============================================================================
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 flight_ENV_ROOT=${flight_ENV_ROOT:-${flight_ROOT}/var/lib/env}
 flight_ENV_CACHE=${flight_ENV_CACHE:-${flight_ROOT}/var/cache/env}
 flight_ENV_BUILD_CACHE=${flight_ENV_BUILD_CACHE:-${flight_ROOT}/var/cache/env/build}
@@ -113,24 +115,13 @@ fi
 # Activate `module` command
 . ${flight_ENV_ROOT}/share/lmod/8.1/lmod/8.1/init/profile
 
-# Install EasyBuild
-if [ ! -f bootstrap_eb.py ]; then
-  env_stage "Fetching prerequisite (easybuild)"
-  wget https://raw.githubusercontent.com/easybuilders/easybuild-framework/develop/easybuild/scripts/bootstrap_eb.py
-fi
-
 env_stage "Bootstrapping EasyBuild environment (easybuild@${name})"
-
-if ! which python &>/dev/null; then
-  PYTHON=python3
-else
-  PYTHON=python
-fi
 
 if [ "$UID" == "0" ]; then
   mkdir "${flight_ENV_ROOT}/easybuild+${name}"
   chown nobody "${flight_ENV_ROOT}/easybuild+${name}"
-  su -s /bin/bash nobody -c "$PYTHON bootstrap_eb.py ${flight_ENV_ROOT}/easybuild+${name}"
+  chown nobody "${flight_ENV_BUILD_CACHE}"
+  su -s /bin/bash nobody "${SCRIPT_DIR}/stage-2-install.sh" "${name}"
 else
-  $PYTHON bootstrap_eb.py ${flight_ENV_ROOT}/easybuild+${name}
+  /bin/bash "${SCRIPT_DIR}/stage-2-install.sh" "${name}"
 fi

--- a/easybuild/global-install.sh
+++ b/easybuild/global-install.sh
@@ -37,11 +37,11 @@ if [ -z "$name" ]; then
   exit 1
 fi
 
-# create directory structure
+# Create directory structure
 mkdir -p ${flight_ENV_CACHE} ${flight_ENV_BUILD_CACHE} ${flight_ENV_ROOT}
 cd ${flight_ENV_BUILD_CACHE}
 
-# Stop any existing activatged EasyBuild environment from getting in
+# Stop any existing activated EasyBuild environment from getting in
 # the way.
 MODULEPATH=""
 
@@ -49,15 +49,19 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
-# build LUA
 env_stage "Verifying prerequisites"
+
 if [ "$distro" != "rhel8" ]; then
-  # build LUA
+  # Build LUA
   if [ ! -f lua-5.1.4.9.tar.bz2 ]; then
     env_stage "Fetching prerequisite (lua)"
     wget https://sourceforge.net/projects/lmod/files/lua-5.1.4.9.tar.bz2
+  fi
+  if [ ! -d lua-5.1.4.9 ]; then
     env_stage "Extracting prerequisite (lua)"
     tar xjf lua-5.1.4.9.tar.bz2
+  fi
+  if [ ! -d ${flight_ENV_ROOT}/share/lua/5.1.4.9 ]; then
     cd lua-5.1.4.9
     env_stage "Building prerequisite (lua)"
     ./configure --with-static=yes --prefix=${flight_ENV_ROOT}/share/lua/5.1.4.9
@@ -69,7 +73,7 @@ if [ "$distro" != "rhel8" ]; then
   PATH=${flight_ENV_ROOT}/share/lua/5.1.4.9/bin:$PATH
 fi
 
-# build Tcl
+# Build Tcl
 if [ ! -d ${flight_ENV_ROOT}/share/tcl/8.6.9 ]; then
   if [ ! -f tcl8.6.9-src.tar.gz ]; then
     env_stage "Fetching prerequisite (tcl)"
@@ -88,11 +92,16 @@ if [ ! -d ${flight_ENV_ROOT}/share/tcl/8.6.9 ]; then
 fi
 PATH=${flight_ENV_ROOT}/share/tcl/8.6.9/bin:$PATH
 
+# Build lmod.
 if [ ! -f Lmod-8.1.tar.bz2 ]; then
   env_stage "Fetching prerequisite (lmod)"
   wget https://sourceforge.net/projects/lmod/files/Lmod-8.1.tar.bz2
+fi
+if [ ! -d Lmod-8.1 ]; then
   env_stage "Extracting prerequisite (lmod)"
   tar xjf Lmod-8.1.tar.bz2
+fi
+if [ ! -f ${flight_ENV_ROOT}/share/lmod/8.1/lmod/8.1/init/profile ]; then
   cd Lmod-8.1
   env_stage "Configuring prerequisite (lmod)"
   ./configure --prefix=${flight_ENV_ROOT}/share/lmod/8.1 --with-fastTCLInterp=no
@@ -101,7 +110,7 @@ if [ ! -f Lmod-8.1.tar.bz2 ]; then
   cd ..
 fi
 
-# activate `module` command
+# Activate `module` command
 . ${flight_ENV_ROOT}/share/lmod/8.1/lmod/8.1/init/profile
 
 # Install EasyBuild

--- a/easybuild/stage-2-install.sh
+++ b/easybuild/stage-2-install.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Environment.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Environment is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Environment. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Environment, please visit:
+# https://github.com/openflighthpc/flight-env
+# ==============================================================================
+set -e
+
+name=$1
+
+# Use flight-python to install the temporary version of EasyBuild.
+PATH=/opt/flight/opt/python/bin:$PATH
+PYTHON=python
+
+# Pick installation prefix, and install EasyBuild into it
+export EB_TMPDIR=/tmp/$USER/eb_tmp
+$PYTHON -m pip install --ignore-installed --prefix $EB_TMPDIR easybuild
+
+# Update environment to use the temporary EasyBuild installation.
+export PATH=$EB_TMPDIR/bin:$PATH
+export PYTHONPATH=$(/bin/ls -rtd -1 $EB_TMPDIR/lib*/python*/site-packages | tail -1):$PYTHONPATH
+export EB_PYTHON=$PYTHON
+
+eb --install-latest-eb-release --prefix ${flight_ENV_ROOT}/easybuild+${name}

--- a/easybuild/user-install.sh
+++ b/easybuild/user-install.sh
@@ -37,11 +37,11 @@ if [ -z "$name" ]; then
   exit 1
 fi
 
-# create directory structure
+# Create directory structure
 mkdir -p ${flight_ENV_CACHE} ${flight_ENV_BUILD_CACHE} ${flight_ENV_ROOT}
 cd ${flight_ENV_BUILD_CACHE}
 
-# Stop any existing activatged EasyBuild environment from getting in
+# Stop any existing activated EasyBuild environment from getting in
 # the way.
 MODULEPATH=""
 
@@ -49,15 +49,19 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
-# build LUA
 env_stage "Verifying prerequisites"
+
 if [ "$distro" != "rhel8" ]; then
-  # build LUA
+  # Build LUA
   if [ ! -f lua-5.1.4.9.tar.bz2 ]; then
     env_stage "Fetching prerequisite (lua)"
     wget https://sourceforge.net/projects/lmod/files/lua-5.1.4.9.tar.bz2
+  fi
+  if [ ! -d lua-5.1.4.9 ]; then
     env_stage "Extracting prerequisite (lua)"
     tar xjf lua-5.1.4.9.tar.bz2
+  fi
+  if [ ! -d ${flight_ENV_ROOT}/share/lua/5.1.4.9 ]; then
     cd lua-5.1.4.9
     env_stage "Building prerequisite (lua)"
     ./configure --with-static=yes --prefix=${flight_ENV_ROOT}/share/lua/5.1.4.9
@@ -69,7 +73,7 @@ if [ "$distro" != "rhel8" ]; then
   PATH=${flight_ENV_ROOT}/share/lua/5.1.4.9/bin:$PATH
 fi
 
-# build Tcl
+# Build Tcl
 if [ ! -d ${flight_ENV_ROOT}/share/tcl/8.6.9 ]; then
   if [ ! -f tcl8.6.9-src.tar.gz ]; then
     env_stage "Fetching prerequisite (tcl)"
@@ -88,11 +92,16 @@ if [ ! -d ${flight_ENV_ROOT}/share/tcl/8.6.9 ]; then
 fi
 PATH=${flight_ENV_ROOT}/share/tcl/8.6.9/bin:$PATH
 
+# Build lmod.
 if [ ! -f Lmod-8.1.tar.bz2 ]; then
   env_stage "Fetching prerequisite (lmod)"
   wget https://sourceforge.net/projects/lmod/files/Lmod-8.1.tar.bz2
+fi
+if [ ! -d Lmod-8.1 ]; then
   env_stage "Extracting prerequisite (lmod)"
   tar xjf Lmod-8.1.tar.bz2
+fi
+if [ ! -f ${flight_ENV_ROOT}/share/lmod/8.1/lmod/8.1/init/profile ]; then
   cd Lmod-8.1
   env_stage "Configuring prerequisite (lmod)"
   ./configure --prefix=${flight_ENV_ROOT}/share/lmod/8.1 --with-fastTCLInterp=no
@@ -101,7 +110,7 @@ if [ ! -f Lmod-8.1.tar.bz2 ]; then
   cd ..
 fi
 
-# activate `module` command
+# Activate `module` command
 . ${flight_ENV_ROOT}/share/lmod/8.1/lmod/8.1/init/profile
 
 # Install EasyBuild

--- a/easybuild/user-install.sh
+++ b/easybuild/user-install.sh
@@ -27,6 +27,8 @@
 # ==============================================================================
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 flight_ENV_ROOT=${flight_ENV_ROOT:-$HOME/.local/share/flight/env}
 flight_ENV_CACHE=${flight_ENV_CACHE:-$HOME/.cache/flight/env}
 flight_ENV_BUILD_CACHE=${flight_ENV_BUILD_CACHE:-$HOME/.cache/flight/env/build}
@@ -113,18 +115,9 @@ fi
 # Activate `module` command
 . ${flight_ENV_ROOT}/share/lmod/8.1/lmod/8.1/init/profile
 
-# Install EasyBuild
-if [ ! -f bootstrap_eb.py ]; then
-  env_stage "Fetching prerequisite (easybuild)"
-  wget https://raw.githubusercontent.com/easybuilders/easybuild-framework/develop/easybuild/scripts/bootstrap_eb.py
-fi
-
 env_stage "Bootstrapping EasyBuild environment (easybuild@${name})"
 
-if ! which python &>/dev/null; then
-  PYTHON=python3
-else
-  PYTHON=python
-fi
+/bin/bash "${SCRIPT_DIR}/stage-2-install.sh" "${name}"
 
-$PYTHON bootstrap_eb.py ${flight_ENV_ROOT}/easybuild+${name}
+# Remove the temporary EasyBuild installation.
+rm -rf "$EB_TMPDIR"


### PR DESCRIPTION
Creation of easybuild environments has stopped working.  The previous method used the EasyBuild boot strap script.  That script goes through a number of steps to install EasyBuild:

0. Install `setuptools`/`distribute` *if needed*.
1. Use `easy_install` to install a temporary version of EasyBuild.  `easy_install` uses the `setuptools`/`distribute` installed or detected in step 0.
2. Use the temporary EasyBuild installed in step 1 to install the permanent EasyBuild.

The issue that we're facing is that in step 0, the installed version of `setuptools`/`distribute` is being detected.  Then in step 2, `easy_install` is unable to communicate with PyPI because the `setuptools`/`distribute` is too old.  I suspect that this is due to PyPI being updated.

According to [this github comment](https://github.com/easybuilders/easybuild-framework/issues/3690#issuecomment-848982184) we are no longer using the recommended method to install EasyBuild.  Instead we should:

1. Use `pip` to install a temporary EasyBuild.
2. Use the temporary EasyBuild installed in step 1 to install the permanent EasyBuild.

Unfortunately, simply swapping out the old method to the new doesn't work. The problem being that Python 2 on Centos 7 doesn't have a `pip` module.  We could look into installing `pip` for Python 2, but that doesn't seem any simpler than fixing `setuptools`/`distribute` in the first case.

The `pip` method of installation does work with Centos's `python3` package.  So adding a dependency on `python3` to `flight-env` might be one solution.

Another solution would be to use the not-yet-released `flight-python` package, which packages up Python 3.

This PR adjusts the installation of the easybuild environment to use `flight-python`.  It also, makes the installation scripts more robust if the installation should fail part way through.
