### PR TITLE
[WIP] Update Spack to v0.17.2

### DIFF
--- a/spack/activate.bash.erb
+++ b/spack/activate.bash.erb
@@ -29,8 +29,6 @@ export flight_ENV_orig_PS1="$PS1"
 
 source <%= env_root %>/spack+<%= env_name %>/share/spack/setup-env.sh
 
-export -f module
-
 export flight_ENV_active=spack@<%= env_name %>
 export flight_ENV_scope=<%= env_global ? 'global' : 'user' %>
 export flight_ENV_dir=<%= env_root %>/spack+<%= env_name %>

--- a/spack/activate.tcsh.erb
+++ b/spack/activate.tcsh.erb
@@ -29,7 +29,6 @@ set flight_ENV_orig_prompt = "$prompt"
 
 setenv SPACK_ROOT <%= env_root %>/spack+<%= env_name %>
 source <%= env_root %>/spack+<%= env_name %>/share/spack/setup-env.csh
-eval `spack --print-shell-vars csh,modules`
 source ${_sp_module_prefix}/Modules/init/tcsh
 
 setenv flight_ENV_active spack@<%= env_name %>

--- a/spack/global-install.sh
+++ b/spack/global-install.sh
@@ -42,14 +42,14 @@ mkdir -p ${flight_ENV_CACHE} ${flight_ENV_BUILD_CACHE} ${flight_ENV_ROOT}
 cd ${flight_ENV_BUILD_CACHE}
 
 env_stage "Verifying prerequisites"
-if [ ! -f spack-v0.14.1.tar.gz ]; then
+if [ ! -f spack-v0.17.2.tar.gz ]; then
   env_stage "Fetching prerequisite (spack)"
-  wget https://github.com/spack/spack/archive/v0.14.1.tar.gz -O spack-v0.14.1.tar.gz
+  wget https://github.com/spack/spack/archive/v0.17.2.tar.gz -O spack-v0.17.2.tar.gz
 fi
 
 mkdir -p ${flight_ENV_ROOT}/spack+${name}
 env_stage "Extracting Spack hierarchy (spack@${name})"
-tar -C ${flight_ENV_ROOT}/spack+${name} -xzf spack-v0.14.1.tar.gz --strip-components=1
+tar -C ${flight_ENV_ROOT}/spack+${name} -xzf spack-v0.17.2.tar.gz --strip-components=1
 cd ${flight_ENV_ROOT}/spack+${name}
 env_stage "Bootstrapping Spack environment (spack@${name})"
 if ! which python &>/dev/null; then

--- a/spack/global-install.sh
+++ b/spack/global-install.sh
@@ -55,4 +55,3 @@ env_stage "Bootstrapping Spack environment (spack@${name})"
 if ! which python &>/dev/null; then
   sed -i -e 's,#!/usr/bin/env python$,#!/usr/bin/env python3,g' bin/spack
 fi
-bin/spack bootstrap

--- a/spack/info.md
+++ b/spack/info.md
@@ -25,7 +25,7 @@ to build combinatorial versions of software for testing.
 
 ## ENVIRONMENT CREATION
 
-This environment provides Spack v0.14.1. It is possible to create
+This environment provides Spack v0.17.2. It is possible to create
 either user-level Spack environments or, if you have write access to
 the global environment tree, to create system-wide Spack environments.
 

--- a/spack/user-install.sh
+++ b/spack/user-install.sh
@@ -42,14 +42,14 @@ mkdir -p ${flight_ENV_CACHE} ${flight_ENV_BUILD_CACHE} ${flight_ENV_ROOT}
 cd ${flight_ENV_BUILD_CACHE}
 
 env_stage "Verifying prerequisites"
-if [ ! -f spack-v0.14.1.tar.gz ]; then
+if [ ! -f spack-v0.17.2.tar.gz ]; then
   env_stage "Fetching prerequisite (spack)"
-  wget https://github.com/spack/spack/archive/v0.14.1.tar.gz -O spack-v0.14.1.tar.gz
+  wget https://github.com/spack/spack/archive/v0.17.2.tar.gz -O spack-v0.17.2.tar.gz
 fi
 
 mkdir -p ${flight_ENV_ROOT}/spack+${name}
 env_stage "Extracting Spack hierarchy (spack@${name})"
-tar -C ${flight_ENV_ROOT}/spack+${name} -xzf spack-v0.14.1.tar.gz --strip-components=1
+tar -C ${flight_ENV_ROOT}/spack+${name} -xzf spack-v0.17.2.tar.gz --strip-components=1
 cd ${flight_ENV_ROOT}/spack+${name}
 env_stage "Bootstrapping Spack environment (spack@${name})"
 if ! which python &>/dev/null; then

--- a/spack/user-install.sh
+++ b/spack/user-install.sh
@@ -55,4 +55,3 @@ env_stage "Bootstrapping Spack environment (spack@${name})"
 if ! which python &>/dev/null; then
   sed -i -e 's,#!/usr/bin/env python$,#!/usr/bin/env python3,g' bin/spack
 fi
-bin/spack bootstrap


### PR DESCRIPTION
_**This is a WIP PR as there are still issues getting Spack to run, this will be used to track issues + changes**_

Outstanding Issues:
- ~~`spack bootstrap` has [been changed](https://spack.io/changes-spack-v017/) and it doesn't look clear that there's another way to bootstrap besides trying to install something (such that it'll do it's bootstrapping in the background)~~ -> Addressed with [fbc0dbf](https://github.com/openflighthpc/flight-env-types/pull/3/commits/fbc0dbf430b902082b206b897870084d1999f741)
- `spack install` Python version warnings
    ```
    Warning: Spack will not check SSL certificates. You need to update your Python to enable certificate verification.
    ```
- ~~Module function seems to have been removed from the spack environment file (`<%= env_root %>/spack+<%= env_name %>/share/spack/setup-env.sh`)~~ -> Addressed with [d9c6e8c](https://github.com/openflighthpc/flight-env-types/pull/3/commits/d9c6e8c24d3ebaafe2968f49300142a9f43431c2)
    ```shell
    $ flight env activate spack
    -bash: export: module: not a function
    ```