### PR TITLE
Update easybuild scripts to support RHEL 9

### DIFF
--- a/easybuild/global-install.sh
+++ b/easybuild/global-install.sh
@@ -51,9 +51,13 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 env_stage "Verifying prerequisites"
 
-if [ "$distro" != "rhel8" ]; then
+if [[ "$distro" != "rhel8" && "$distro" != "rhel9" ]]; then
   # Build LUA
   if [ ! -f lua-5.1.4.9.tar.bz2 ]; then
     env_stage "Fetching prerequisite (lua)"

--- a/easybuild/user-install.sh
+++ b/easybuild/user-install.sh
@@ -51,9 +51,13 @@ if [ -f /etc/redhat-release ] && grep -q 'release 8' /etc/redhat-release; then
   distro=rhel8
 fi
 
+if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
+  distro=rhel9
+fi
+
 env_stage "Verifying prerequisites"
 
-if [ "$distro" != "rhel8" ]; then
+if [[ "$distro" != "rhel8" && "$distro" != "rhel9" ]]; then
   # Build LUA
   if [ ! -f lua-5.1.4.9.tar.bz2 ]; then
     env_stage "Fetching prerequisite (lua)"


### PR DESCRIPTION
None of the system-specific dependencies have changed in the Flight Env build process between RHEL 8 and RHEL 9; ideally, this means that we can simply add RHEL 9 to the conditional that builds `lua` manually if not running RHEL 8.