### PR TITLE
More CentOS 9 stuff

### DIFF
--- a/easybuild/global-install.sh
+++ b/easybuild/global-install.sh
@@ -57,7 +57,7 @@ fi
 
 env_stage "Verifying prerequisites"
 
-if [[ "$distro" != "rhel8" && "$distro" != "rhel9" ]]; then
+if [[ "$distro" != "rhel8" ]]; then
   # Build LUA
   if [ ! -f lua-5.1.4.9.tar.bz2 ]; then
     env_stage "Fetching prerequisite (lua)"

--- a/easybuild/user-install.sh
+++ b/easybuild/user-install.sh
@@ -57,7 +57,7 @@ fi
 
 env_stage "Verifying prerequisites"
 
-if [[ "$distro" != "rhel8" && "$distro" != "rhel9" ]]; then
+if [[ "$distro" != "rhel8" ]]; then
   # Build LUA
   if [ ! -f lua-5.1.4.9.tar.bz2 ]; then
     env_stage "Fetching prerequisite (lua)"


### PR DESCRIPTION
CentOS 9 doesn't ship with the version of `lua` that `EasyBuild` expects; removing it from the RHEL 8 check installs it correctly.