### PR TITLE
Ensure `pip` is isolated from any user-based configuration

### DIFF
--- a/conda/activate.bash.erb
+++ b/conda/activate.bash.erb
@@ -48,3 +48,5 @@ else
     fi
 fi
 unset __conda_setup
+
+export PIP_ISOLATED=true

--- a/conda/activate.tcsh.erb
+++ b/conda/activate.tcsh.erb
@@ -43,3 +43,5 @@ if ( -f "<%= env_root %>/conda+<%= env_name %>/etc/profile.d/conda.csh" ) then
 else
     setenv PATH="<%= env_root %>/conda+<%= env_name %>/bin:$PATH"
 endif
+
+setenv PIP_ISOLATED true

--- a/conda/deactivate.bash.erb
+++ b/conda/deactivate.bash.erb
@@ -35,3 +35,5 @@ PS1="${flight_ENV_orig_PS1}"
 unset flight_ENV_orig_PS1
 PATH="${flight_ENV_orig_PATH}"
 unset flight_ENV_orig_PATH
+
+unset PIP_ISOLATED

--- a/conda/deactivate.tcsh.erb
+++ b/conda/deactivate.tcsh.erb
@@ -39,3 +39,5 @@ set prompt="${flight_ENV_orig_prompt}"
 unset flight_ENV_orig_prompt
 setenv PATH "${flight_ENV_orig_PATH}"
 unset flight_ENV_orig_PATH
+
+unsetenv PIP_ISOLATED


### PR DESCRIPTION
Without establishing this, it's possible for a `~/.pydistutils.cfg` file to cause `pip` to install to unexpected locations while operating within a Conda environment.